### PR TITLE
Proper social sharing

### DIFF
--- a/components/articles/Article.js
+++ b/components/articles/Article.js
@@ -102,7 +102,7 @@ const Article = ({
           {fiberyRenderer(text.content)}
         </div>
         <div className="article-page__share">
-          <ShareButtons urlPath={router.asPath} title={title} />
+          <ShareButtons urlPath={router.asPath} text={{ basic: title }} />
         </div>
         <div className="article-page__other-tags">
           {tags.map(tag => (

--- a/components/articles/Article.js
+++ b/components/articles/Article.js
@@ -102,7 +102,7 @@ const Article = ({
           {fiberyRenderer(text.content)}
         </div>
         <div className="article-page__share">
-          <ShareButtons urlPath={router.asPath} text={{ basic: title }} />
+          <ShareButtons urlPath={router.asPath} basicText={title} />
         </div>
         <div className="article-page__other-tags">
           {tags.map(tag => (

--- a/components/articles/cards/auto.js
+++ b/components/articles/cards/auto.js
@@ -9,8 +9,8 @@ export const SCREENS = ['mobile', 'touch', 'tablet', 'tablet-large', 'desktop'];
 export const ARTICLE_CARD_SIZES_BY_CONTEXT = {
   featured: ['square-s', 'm', 'l', 'xl', 'xxl'],
   'two-in-row': {
-    first: ['m', 'square-s', 'm', 'l', 'm'],
-    second: ['square-s', 'square-s', 'm', 'l', 'm'],
+    first: ['square-s', 'm', 'l', 'm', 'm'],
+    second: ['square-s', 'm', 'l', 'square-s', 'm'],
   },
   'articles-by-tag-2': ['square-s', 'm', 'square-m', 'l', 'square-m'],
   'articles-by-tag-3': ['square-s', 'm', 'square-s', 'square-m', 'square-s'],

--- a/components/common/Button.js
+++ b/components/common/Button.js
@@ -3,33 +3,43 @@ import './ui/button.scss';
 import React from 'react';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
-import noop from 'lodash/noop';
 
-const Button = ({ className, pending, icon, ...props }) => (
+import Icon from 'components/common/ui/Icon';
+
+import { IconPackShape } from 'utils/customPropTypes';
+
+const Button = ({ className, children, pending, icon: { pack, name }, ...props }) => (
   <button
     type="button"
-    className={cn('wir-button', className, {
-      'wir-button__loading': pending,
-      'wir-button__icon': icon,
+    className={cn('wir-kit-button', className, {
+      'wir-kit-button__loading': pending,
     })}
     {...props}
-  />
+  >
+    {name && <Icon className="wir-kit-button__icon" pack={pack} name={name} />}
+    {children}
+  </button>
 );
 
 Button.propTypes = {
   className: PropTypes.string,
-  onClick: PropTypes.func,
+  children: PropTypes.node.isRequired,
   pending: PropTypes.bool,
+  icon: PropTypes.shape({
+    pack: IconPackShape,
+    name: PropTypes.string,
+  }),
   disabled: PropTypes.bool,
-  icon: PropTypes.bool,
 };
 
 Button.defaultProps = {
-  onClick: noop,
   className: '',
   pending: false,
+  icon: {
+    pack: 's',
+    name: '',
+  },
   disabled: false,
-  icon: false,
 };
 
 export default Button;

--- a/components/common/ButtonGroup.js
+++ b/components/common/ButtonGroup.js
@@ -1,4 +1,5 @@
 import './ui/button-group.scss';
+
 import React from 'react';
 import cn from 'classnames';
 import PropTypes from 'prop-types';

--- a/components/common/layout/Footer.js
+++ b/components/common/layout/Footer.js
@@ -59,7 +59,7 @@ const Footer = () => (
               <div className="footer__header">
                 <Text id="footer.share" />
               </div>
-              <ShareButtons title={useLocalization('common.project-description')} />
+              <ShareButtons text={{ basic: useLocalization('common.project-description') }} />
             </div>
           </div>
         </div>

--- a/components/common/layout/Footer.js
+++ b/components/common/layout/Footer.js
@@ -59,7 +59,7 @@ const Footer = () => (
               <div className="footer__header">
                 <Text id="footer.share" />
               </div>
-              <ShareButtons text={{ basic: useLocalization('common.project-description') }} />
+              <ShareButtons basixText={useLocalization('common.project-description')} />
             </div>
           </div>
         </div>

--- a/components/common/ui/Icon.js
+++ b/components/common/ui/Icon.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
 
+import { IconPackShape } from 'utils/customPropTypes';
+
 const Icon = ({ className, name, pack, size, ...props }) => (
   <i
     className={cn(className, `fa${pack} fa-${name}`, size && `fa-${size}`)}
@@ -14,7 +16,7 @@ Icon.propTypes = {
   className: PropTypes.string,
   name: PropTypes.string.isRequired,
   size: PropTypes.string,
-  pack: PropTypes.oneOf(['s', 'r', 'b']),
+  pack: IconPackShape,
 };
 
 Icon.defaultProps = {

--- a/components/common/ui/button-group.scss
+++ b/components/common/ui/button-group.scss
@@ -11,13 +11,11 @@
     border-left: 0;
     float: left;
     outline: none;
-    padding: 0.6rem 0.8rem;
     text-align: center;
 
     &__icon {
       flex-basis: auto;
       flex-grow: 1;
-      padding: 0.3rem;
     }
 
     &:hover {

--- a/components/common/ui/button.scss
+++ b/components/common/ui/button.scss
@@ -1,10 +1,25 @@
 @import 'variables';
 
-.wir-button {
-  background-color: $primary;
+.wir-kit-button {
+  background-color: $primary-white;
+  border: 1px solid $primary-grey-article-table;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 24px;
+  outline: none;
+  padding: 10px 20px;
+
+  &:active {
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.25);
+  }
 
   &:hover {
-    background-color: $primary-caribbean-green;
+    color: $primary;
+  }
+
+  &__icon {
+    padding-right: 5px;
   }
 
   &__loading {

--- a/components/social/ShareButtons.js
+++ b/components/social/ShareButtons.js
@@ -1,57 +1,92 @@
 import './social-buttons.scss';
 
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import qs from 'qs';
+import cn from 'classnames';
 
-import { localize, useLocaleContext } from 'components/common/Text';
+import Text, { localize, useLocaleContext } from 'components/common/Text';
 import Icon from 'components/common/ui/Icon';
+import Button from 'components/common/Button';
 import ButtonGroup from 'components/common/ButtonGroup';
 
 import { SHARE_NETWORKS } from 'constants/social';
 import { DOMAIN_SECURE } from 'constants';
 
+const POPUP_WINDOW_PARAMS = 'width=600,height=400';
+
 const ShareButtons = ({ urlPath, text: { basic, extended } }) => {
   const lang = useLocaleContext();
+  const [forceButtonGroup, setForceButtonGroup] = useState(false);
+
   return (
-    <ButtonGroup className="wir-social-buttons" icon>
-      {SHARE_NETWORKS.map(({ id, icon = id, baseUrl, getParams }) => {
-        const text = id === 'twitter' ? extended || basic : basic;
-        return (
-          <button
-            key={id}
-            className={`wir-button wir-button__icon wir-social-buttons__button wir-social-buttons__button--${id}`}
-            title={localize(`common.share-${id}`, lang)}
-            type="button"
-            onClick={() => {
-              window.open(
-                `${baseUrl}?${qs.stringify(getParams(`${DOMAIN_SECURE}${urlPath}`, text))}`,
-                localize(`common.share-link`, lang),
-                'width=600,height=400'
-              );
-            }}
-          >
-            <Icon pack="b" name={icon} />
-          </button>
-        );
-      })}
-    </ButtonGroup>
+    <>
+      <div
+        className={cn('wir-social-buttons__native', {
+          'wir-social-buttons__native--hidden': forceButtonGroup,
+        })}
+      >
+        <Button
+          onClick={() => {
+            if (navigator.share) {
+              navigator.share({
+                title: basic,
+                url: `${DOMAIN_SECURE}${urlPath}`,
+              });
+            } else {
+              setForceButtonGroup(true);
+            }
+          }}
+          icon={{
+            pack: 's',
+            name: 'external-link-alt',
+          }}
+        >
+          <Text id="common.share-link" />
+        </Button>
+      </div>
+      <div
+        className={cn('wir-social-buttons__generic', {
+          'wir-social-buttons__generic--shown': forceButtonGroup,
+        })}
+      >
+        <ButtonGroup className="wir-social-buttons" icon>
+          {SHARE_NETWORKS.map(({ id, icon = id, baseUrl, getParams }) => {
+            const text = id === 'twitter' ? extended || basic : basic;
+            return (
+              <button
+                key={id}
+                className={`wir-button wir-button__icon wir-social-buttons__button wir-social-buttons__button--${id}`}
+                title={localize(`common.share-${id}`, lang)}
+                type="button"
+                onClick={() => {
+                  window.open(
+                    `${baseUrl}?${qs.stringify(getParams(`${DOMAIN_SECURE}${urlPath}`, text))}`,
+                    localize(`common.share-link`, lang),
+                    POPUP_WINDOW_PARAMS
+                  );
+                }}
+              >
+                <Icon pack="b" name={icon} />
+              </button>
+            );
+          })}
+        </ButtonGroup>
+      </div>
+    </>
   );
 };
 
 ShareButtons.propTypes = {
   urlPath: PropTypes.string,
-  text: {
+  text: PropTypes.shape({
     basic: PropTypes.string.isRequired,
     extended: PropTypes.string,
-  },
+  }).isRequired,
 };
 
 ShareButtons.defaultProps = {
   urlPath: '',
-  text: {
-    extended: '',
-  },
 };
 
 export default ShareButtons;

--- a/components/social/ShareButtons.js
+++ b/components/social/ShareButtons.js
@@ -15,7 +15,7 @@ import { DOMAIN_SECURE } from 'constants';
 
 const POPUP_WINDOW_PARAMS = 'width=600,height=400';
 
-const ShareButtons = ({ urlPath, text: { basic, extended } }) => {
+const ShareButtons = ({ urlPath, basicText, extendedText }) => {
   const lang = useLocaleContext();
   const [forceButtonGroup, setForceButtonGroup] = useState(false);
 
@@ -30,7 +30,7 @@ const ShareButtons = ({ urlPath, text: { basic, extended } }) => {
           onClick={() => {
             if (navigator.share) {
               navigator.share({
-                title: basic,
+                title: basicText,
                 url: `${DOMAIN_SECURE}${urlPath}`,
               });
             } else {
@@ -52,7 +52,7 @@ const ShareButtons = ({ urlPath, text: { basic, extended } }) => {
       >
         <ButtonGroup className="wir-social-buttons" icon>
           {SHARE_NETWORKS.map(({ id, icon = id, baseUrl, getParams }) => {
-            const text = id === 'twitter' ? extended || basic : basic;
+            const text = id === 'twitter' ? extendedText || basicText : basicText;
             return (
               <button
                 key={id}
@@ -79,14 +79,13 @@ const ShareButtons = ({ urlPath, text: { basic, extended } }) => {
 
 ShareButtons.propTypes = {
   urlPath: PropTypes.string,
-  text: PropTypes.shape({
-    basic: PropTypes.string.isRequired,
-    extended: PropTypes.string,
-  }).isRequired,
+  basicText: PropTypes.string.isRequired,
+  extendedText: PropTypes.string,
 };
 
 ShareButtons.defaultProps = {
   urlPath: '',
+  extendedText: '',
 };
 
 export default ShareButtons;

--- a/components/social/ShareButtons.js
+++ b/components/social/ShareButtons.js
@@ -7,37 +7,51 @@ import qs from 'qs';
 import { localize, useLocaleContext } from 'components/common/Text';
 import Icon from 'components/common/ui/Icon';
 import ButtonGroup from 'components/common/ButtonGroup';
-import ExternalLink from 'components/common/ExternalLink';
 
 import { SHARE_NETWORKS } from 'constants/social';
 import { DOMAIN_SECURE } from 'constants';
 
-const ShareButtons = ({ urlPath, title }) => {
+const ShareButtons = ({ urlPath, text: { basic, extended } }) => {
   const lang = useLocaleContext();
   return (
     <ButtonGroup className="wir-social-buttons" icon>
-      {SHARE_NETWORKS.map(({ id, icon = id, baseUrl, getParams }) => (
-        <ExternalLink
-          key={id}
-          className={`wir-button wir-button__icon wir-social-buttons__button wir-social-buttons__button--${id}`}
-          href={`${baseUrl}?${qs.stringify(getParams(`${DOMAIN_SECURE}${urlPath}`, title))}`}
-          title={localize(`common.share-${id}`, lang)}
-          custom
-        >
-          <Icon pack="b" name={icon} />
-        </ExternalLink>
-      ))}
+      {SHARE_NETWORKS.map(({ id, icon = id, baseUrl, getParams }) => {
+        const text = id === 'twitter' ? extended || basic : basic;
+        return (
+          <button
+            key={id}
+            className={`wir-button wir-button__icon wir-social-buttons__button wir-social-buttons__button--${id}`}
+            title={localize(`common.share-${id}`, lang)}
+            type="button"
+            onClick={() => {
+              window.open(
+                `${baseUrl}?${qs.stringify(getParams(`${DOMAIN_SECURE}${urlPath}`, text))}`,
+                localize(`common.share-link`, lang),
+                'width=600,height=400'
+              );
+            }}
+          >
+            <Icon pack="b" name={icon} />
+          </button>
+        );
+      })}
     </ButtonGroup>
   );
 };
 
 ShareButtons.propTypes = {
   urlPath: PropTypes.string,
-  title: PropTypes.string.isRequired,
+  text: {
+    basic: PropTypes.string.isRequired,
+    extended: PropTypes.string,
+  },
 };
 
 ShareButtons.defaultProps = {
   urlPath: '',
+  text: {
+    extended: '',
+  },
 };
 
 export default ShareButtons;

--- a/components/social/social-buttons.scss
+++ b/components/social/social-buttons.scss
@@ -21,5 +21,9 @@
     &--odnoklassniki {
       color: $odnoklassniki-color;
     }
+
+    &--telegram {
+      color: $telegram-color;
+    }
   }
 }

--- a/components/social/social-buttons.scss
+++ b/components/social/social-buttons.scss
@@ -1,9 +1,43 @@
+@import 'responsiveness';
 @import 'variables';
 
 .wir-social-buttons {
+  &__native {
+    display: none;
+
+    @include screen-mobile {
+      display: unset;
+    }
+
+    @include screen-touch {
+      display: unset;
+    }
+
+    &--hidden {
+      // stylelint-disable-next-line declaration-no-important
+      display: none !important;
+    }
+  }
+
+  &__generic {
+    @include screen-mobile {
+      display: none;
+    }
+
+    @include screen-touch {
+      display: none;
+    }
+
+    &--shown {
+      // stylelint-disable-next-line declaration-no-important
+      display: unset !important;
+    }
+  }
+
   &__button {
-    font-size: 1.3rem;
-    padding: 0.3rem;
+    font-size: 22px;
+    line-height: 24px;
+    padding: 10px 0;
     width: 0.5rem;
 
     &--facebook {
@@ -24,6 +58,18 @@
 
     &--telegram {
       color: $telegram-color;
+
+      // It is not clear how to share to telegram on mobile;
+      // it does not work at iOS at least.
+      // Hiding the button until resolved.
+
+      @include screen-mobile {
+        display: none;
+      }
+
+      @include screen-touch {
+        display: none;
+      }
     }
   }
 }

--- a/constants/social.js
+++ b/constants/social.js
@@ -67,6 +67,12 @@ export const SHARE_NETWORKS = [
     baseUrl: 'https://connect.ok.ru/offer',
     getParams: (url, title) => ({ url, title }),
   },
+  {
+    id: 'telegram',
+    icon: 'telegram-plane',
+    baseUrl: 'https://telegram.me/share',
+    getParams: url => ({ url }),
+  },
 ];
 
 export const GA_ID = 'UA-117143376-2';

--- a/constants/social.js
+++ b/constants/social.js
@@ -63,15 +63,15 @@ export const SHARE_NETWORKS = [
     getParams: (url, title) => ({ url, title }),
   },
   {
-    id: 'odnoklassniki',
-    baseUrl: 'https://connect.ok.ru/offer',
-    getParams: (url, title) => ({ url, title }),
-  },
-  {
     id: 'telegram',
     icon: 'telegram-plane',
     baseUrl: 'https://telegram.me/share',
     getParams: url => ({ url }),
+  },
+  {
+    id: 'odnoklassniki',
+    baseUrl: 'https://connect.ok.ru/offer',
+    getParams: (url, title) => ({ url, title }),
   },
 ];
 

--- a/pages/about.js
+++ b/pages/about.js
@@ -51,7 +51,21 @@ const AboutPage = ({ lang }) => (
         </div>
         <div className="about-page__description-text">
           <Text id="about.section-team-subtext">
-            {(thanks, name1, descr1, name2, descr2, name3, descr3, name4, descr4) => (
+            {(
+              thanks,
+              name1,
+              descr1,
+              name2,
+              descr2,
+              name3,
+              descr3,
+              name4,
+              descr4,
+              name5,
+              descr5,
+              name6,
+              descr6
+            ) => (
               <>
                 {thanks}
                 <b>{name1}</b>
@@ -62,6 +76,10 @@ const AboutPage = ({ lang }) => (
                 {descr3}
                 <b>{name4}</b>
                 {descr4}
+                <b>{name5}</b>
+                {descr5}
+                <b>{name6}</b>
+                {descr6}
               </>
             )}
           </Text>

--- a/pages/about.js
+++ b/pages/about.js
@@ -21,7 +21,7 @@ const getLogoUrl = name =>
 
 const AboutPage = ({ lang }) => (
   <>
-    <MetaTitle title={localize('about.meta-title', lang)} type="article" />
+    <MetaTitle title={localize('about.meta-title', lang)} />
     <MetaDescription description={localize('about.meta-description', lang)} />
     <MetaKeywords keywords={localize('about.meta-keywords', lang)} />
     <MetaImage url={DEFAULT_IMAGE} small />
@@ -51,7 +51,7 @@ const AboutPage = ({ lang }) => (
         </div>
         <div className="about-page__description-text">
           <Text id="about.section-team-subtext">
-            {(thanks, name1, descr1, name2, descr2, name3, descr3) => (
+            {(thanks, name1, descr1, name2, descr2, name3, descr3, name4, descr4) => (
               <>
                 {thanks}
                 <b>{name1}</b>
@@ -60,6 +60,8 @@ const AboutPage = ({ lang }) => (
                 {descr2}
                 <b>{name3}</b>
                 {descr3}
+                <b>{name4}</b>
+                {descr4}
               </>
             )}
           </Text>

--- a/pages/diary.js
+++ b/pages/diary.js
@@ -35,16 +35,22 @@ const mapStateToProps = (state, { lang }) => ({
   diary: diarySelectors.getCurrent(state, lang),
 });
 
-const getShareText = (date, name) => {
+const getShareText = (date, name, lang, content) => {
   const today = dateIsToday(date);
   const year = getYear(date);
-  return [
-    today ? 'Сёння' : formatDate(date, DATE_FORMAT),
+
+  const base = [
+    today ? 'Сёння' : `${formatDate(date, DATE_FORMAT)} `,
     today && year && `, у ${year} годзе, `,
-    `${name} ${localize('diary.wrote', 'be')}...`,
+    `${name} ${localize('diary.wrote', lang)}`,
   ]
     .filter(Boolean)
     .join('');
+
+  return {
+    basic: `${base}...`,
+    extended: `${base}:\n«${content}...»\n`,
+  };
 };
 
 const DiaryPage = ({
@@ -67,7 +73,7 @@ const DiaryPage = ({
   return (
     <>
       <MetaTitle title={metaTitle} type="article" />
-      <MetaDescription description={`${fiberyToString(content).substring(0, 100)}...`} />
+      <MetaDescription description={`${fiberyToString(content).substring(0, 150)}...`} />
       <MetaKeywords keywords={metaKeywords} />
       <MetaImage url={image ? `${host}${image}` : DEFAULT_IMAGE} small />
 
@@ -94,7 +100,10 @@ const DiaryPage = ({
         </div>
         <div className="diary-page__text">{fiberyRenderer(content)}</div>
         <div className="diary-page__share">
-          <ShareButtons urlPath={router.asPath} title={getShareText(date, name)} />
+          <ShareButtons
+            urlPath={router.asPath}
+            text={getShareText(date, name, lang, fiberyToString(content).substring(0, 140))}
+          />
         </div>
         <DiaryLinkArrows className="diary-page__arrows diary-page__arrows--bottom" size={36} />
       </div>

--- a/pages/diary.js
+++ b/pages/diary.js
@@ -69,11 +69,12 @@ const DiaryPage = ({
     localize('diary.meta-keywords', lang),
   ].join(', ');
   const [first, second] = getLocalizedArticles(articles, lang);
+  const shortContent = fiberyToString(content).substring(0, 140);
 
   return (
     <>
       <MetaTitle title={metaTitle} type="article" />
-      <MetaDescription description={`${fiberyToString(content).substring(0, 150)}...`} />
+      <MetaDescription description={`${shortContent}...`} />
       <MetaKeywords keywords={metaKeywords} />
       <MetaImage url={image ? `${host}${image}` : DEFAULT_IMAGE} small />
 
@@ -102,7 +103,7 @@ const DiaryPage = ({
         <div className="diary-page__share">
           <ShareButtons
             urlPath={router.asPath}
-            text={getShareText(date, name, lang, fiberyToString(content).substring(0, 140))}
+            text={getShareText(date, name, lang, shortContent)}
           />
         </div>
         <DiaryLinkArrows className="diary-page__arrows diary-page__arrows--bottom" size={36} />

--- a/pages/diary.js
+++ b/pages/diary.js
@@ -48,8 +48,8 @@ const getShareText = (date, name, lang, content) => {
     .join('');
 
   return {
-    basic: `${base}...`,
-    extended: `${base}:\n«${content}...»\n`,
+    basicText: `${base}...`,
+    extendedText: `${base}:\n«${content}...»\n`,
   };
 };
 
@@ -101,10 +101,7 @@ const DiaryPage = ({
         </div>
         <div className="diary-page__text">{fiberyRenderer(content)}</div>
         <div className="diary-page__share">
-          <ShareButtons
-            urlPath={router.asPath}
-            text={getShareText(date, name, lang, shortContent)}
-          />
+          <ShareButtons urlPath={router.asPath} {...getShareText(date, name, lang, shortContent)} />
         </div>
         <DiaryLinkArrows className="diary-page__arrows diary-page__arrows--bottom" size={36} />
       </div>

--- a/styles/pages/article.scss
+++ b/styles/pages/article.scss
@@ -97,7 +97,7 @@ $paragraph-spacing: 24px;
 
   &__share {
     margin-top: 72px;
-    width: 200px;
+    width: 300px;
   }
 
   &__other-tags {

--- a/styles/pages/diary.scss
+++ b/styles/pages/diary.scss
@@ -51,7 +51,7 @@
 
   &__share {
     margin: 40px 0;
-    width: 200px;
+    width: 300px;
   }
 }
 

--- a/utils/customPropTypes.js
+++ b/utils/customPropTypes.js
@@ -121,3 +121,5 @@ export const DiaryShape = PropTypes.shape({
     diaryImage: PropTypes.string,
   }),
 });
+
+export const IconPackShape = PropTypes.oneOf(['s', 'r', 'b']);

--- a/utils/fibery/toString.js
+++ b/utils/fibery/toString.js
@@ -13,7 +13,7 @@ const convertContent = (content, init = '') => {
 };
 
 const CONVERTERS = {
-  paragraph: ({ content }) => convertContent(content),
+  paragraph: ({ content }) => `${convertContent(content)} `,
   text: ({ text }) => text,
 };
 


### PR DESCRIPTION
Notes on Web Share API:
https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share
* We only enable generic "Share" button on `mobile` and `touch` devices
* We never show it on `tablet+`. This means iPads, Android tablets and Desktop Safari won't use Web Share API even though they support it
* This is done to prevent Desktop Safari from using native sharing as it useless there - separate share buttons are much better
* In case there's `mobile/touch` device without Web Share API support we fallback to use our own Share Button Group

Also:
* metatags fixes
* card auto context for `two-in-row`
* telegram share button (not on mobile; unclear how to do that)
* popup window on desktop