### PR TITLE
perf(core): add images lazy-loading

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -21,7 +21,7 @@
     "name": "> tag [server]",
     "path": ".next/server/pages/tag.js",
     "running": false,
-    "limit": "27 kB"
+    "limit": "28 kB"
   },
   {
     "name": "> about [server]",
@@ -45,13 +45,13 @@
     "name": "> home [server]",
     "path": ".next/server/pages/index.js",
     "running": false,
-    "limit": "33 kB"
+    "limit": "34 kB"
   },
   {
     "name": "> article [server]",
     "path": ".next/server/pages/article.js",
     "running": false,
-    "limit": "45 kB"
+    "limit": "46 kB"
   },
   {
     "name": "> app",

--- a/components/common/Image.js
+++ b/components/common/Image.js
@@ -1,7 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Image = ({ className, sourceSizes, baseUrl, alt, title, sizes, mode, dimension }) => {
+const Image = ({
+  className,
+  sourceSizes,
+  baseUrl,
+  alt,
+  title,
+  sizes,
+  mode,
+  dimension,
+  inViewport,
+}) => {
   const getSource = (size, x = 1) =>
     `${baseUrl}?${dimension}=${size * x} ${mode === 'w' ? `${size * x}w` : `${x}x`},`;
 
@@ -9,7 +19,16 @@ const Image = ({ className, sourceSizes, baseUrl, alt, title, sizes, mode, dimen
     (acc, size) => `${acc}${getSource(size)}${getSource(size, 2)}`,
     ''
   );
-  return <img className={className} srcSet={srcSet} alt={alt} title={title} sizes={sizes} />;
+  return (
+    <img
+      className={className}
+      srcSet={srcSet}
+      alt={alt}
+      title={title}
+      sizes={sizes}
+      loading={inViewport ? 'eager' : 'lazy'}
+    />
+  );
 };
 
 Image.propTypes = {
@@ -21,6 +40,7 @@ Image.propTypes = {
   sizes: PropTypes.string,
   mode: PropTypes.oneOf(['w', 'x']),
   dimension: PropTypes.oneOf(['w', 'h']),
+  inViewport: PropTypes.bool,
 };
 
 Image.defaultProps = {
@@ -29,6 +49,7 @@ Image.defaultProps = {
   mode: 'w',
   title: '',
   dimension: 'w',
+  inViewport: false,
 };
 
 export default Image;

--- a/components/common/ui/Picture.js
+++ b/components/common/ui/Picture.js
@@ -18,12 +18,12 @@ const BREAKPOINTS = {
 const getMedia = ({ min, max }) =>
   [min && `(min-width: ${min}px)`, max && `(max-width: ${max}px)`].filter(Boolean).join(' and ');
 
-const Picture = ({ className, sources, alt }) => (
+const Picture = ({ className, sources, alt, inViewport }) => (
   <picture className={cn(b(), className)}>
     {Object.entries(sources).map(([screen, src]) => (
       <source key={screen} media={getMedia(BREAKPOINTS[screen])} srcSet={src} />
     ))}
-    <img src={sources.mobile} alt={alt} />
+    <img src={sources.mobile} alt={alt} loading={inViewport ? 'eager' : 'lazy'} />
   </picture>
 );
 
@@ -32,10 +32,12 @@ Picture.propTypes = {
   className: PropTypes.string,
   sources: PropTypes.objectOf(PropTypes.string).isRequired,
   alt: PropTypes.string.isRequired,
+  inViewport: PropTypes.bool,
 };
 
 Picture.defaultProps = {
   className: '',
+  inViewport: false,
 };
 
 export default Picture;

--- a/constants/social.js
+++ b/constants/social.js
@@ -32,7 +32,7 @@ export const NETWORKS = [
   {
     id: 'youtube',
     label: 'YouTube',
-    link: 'https://www.youtube.com/channel/UCoj_6A55mEPeba8ZfBHqfCw',
+    link: 'https://www.youtube.com/c/WirBy',
     color: '#bb0000',
   },
 ];

--- a/features/articles/Article.js
+++ b/features/articles/Article.js
@@ -64,7 +64,10 @@ const Article = ({
   },
 }) => {
   const { brands, authors, ...tagsObject } = tagsByTopic;
-  const renderTagImage = getTagImageRenderer({ className: b('tag-image') });
+  const renderTagImage = getTagImageRenderer({
+    className: b('tag-image'),
+    inViewport: true,
+  });
   const imageUrl = images.page || images.horizontal;
   // https://caniuse.com/#feat=array-flat
   const tags = flatten(Object.values(tagsObject));
@@ -96,6 +99,7 @@ const Article = ({
             alt={title}
             sourceSizes={COVER_SIZES}
             baseUrl={images.page}
+            inViewport
           />
         )}
       </div>

--- a/features/layout/blocks/articles/ArticlesByTag2.js
+++ b/features/layout/blocks/articles/ArticlesByTag2.js
@@ -15,7 +15,7 @@ import styles from './articlesByTag2.module.scss';
 
 const b = bem(styles);
 
-const ArticlesByTag2 = ({ block, data }) => {
+const ArticlesByTag2 = ({ block, data, inViewport }) => {
   const { tagId, articlesIds } = block;
   const { tags, articles } = data;
   const [first, second] = articlesIds.map(id => articles[id]);
@@ -33,6 +33,7 @@ const ArticlesByTag2 = ({ block, data }) => {
             getTagImageRenderer({
               theme: 'dark',
               className: b('logo'),
+              inViewport,
             })(tag)}
           <div className={b('label')}>
             <Text id={`topic.${topicSlug}_essentials`} />: {tagLink}
@@ -43,11 +44,21 @@ const ArticlesByTag2 = ({ block, data }) => {
 
       <div className={b('cards')}>
         <div className={b('card-1')}>
-          <ArticleCard {...first} blockContext={['articles-by-tag-2']} onBackground />
+          <ArticleCard
+            {...first}
+            blockContext={['articles-by-tag-2']}
+            inViewport={inViewport}
+            onBackground
+          />
         </div>
 
         <div className={b('card-2')}>
-          <ArticleCard {...second} blockContext={['articles-by-tag-2']} onBackground />
+          <ArticleCard
+            {...second}
+            blockContext={['articles-by-tag-2']}
+            inViewport={inViewport}
+            onBackground
+          />
         </div>
       </div>
 

--- a/features/layout/blocks/articles/ArticlesByTag3.js
+++ b/features/layout/blocks/articles/ArticlesByTag3.js
@@ -12,7 +12,7 @@ import styles from './articlesByTag3.module.scss';
 
 const b = bem(styles);
 
-const ArticlesByTag3 = ({ block, data }) => {
+const ArticlesByTag3 = ({ block, data, inViewport }) => {
   const { tagId, articlesIds } = block;
   const { tags, articles } = data;
   const tag = tags[tagId];
@@ -31,7 +31,11 @@ const ArticlesByTag3 = ({ block, data }) => {
       <div className={b('cards')}>
         {articlesIds.map((id, index) => (
           <div key={id} className={b(`card-${index + 1}`)}>
-            <ArticleCard {...articles[id]} blockContext={['articles-by-tag-3']} />
+            <ArticleCard
+              {...articles[id]}
+              blockContext={['articles-by-tag-3']}
+              inViewport={inViewport}
+            />
           </div>
         ))}
       </div>

--- a/features/layout/blocks/articles/FeaturedBlock.js
+++ b/features/layout/blocks/articles/FeaturedBlock.js
@@ -5,14 +5,14 @@ import ArticleCard from 'features/layout/cards/article';
 
 import BlockWrapper from 'features/layout/blocks/wrapper';
 
-const FeaturedBlock = ({ block, data }) => {
+const FeaturedBlock = ({ block, data, inViewport }) => {
   // Another usage for FeaturedBlock is a Block A on Topic page.
   const { articleId, frozen } = block;
   const { articles, latestArticles } = data;
   const articleData = frozen ? articles[articleId] : latestArticles[0];
   return (
     <BlockWrapper className="featured">
-      <ArticleCard {...articleData} blockContext={['featured']} />
+      <ArticleCard {...articleData} blockContext={['featured']} inViewport={inViewport} />
     </BlockWrapper>
   );
 };

--- a/features/layout/blocks/articles/LatestArticles.js
+++ b/features/layout/blocks/articles/LatestArticles.js
@@ -10,7 +10,7 @@ const getData = ({ articles, latestArticles }, { id, frozen }, nextIndex) => {
   return [latestArticles[nextIndex], nextIndex + 1];
 };
 
-const LatestArticles = ({ block, data, blocks }) => {
+const LatestArticles = ({ block, data, blocks, inViewport }) => {
   const { articlesIds } = block;
   const [first, second] = articlesIds;
   // TODO: to handle situation with multiple 'featured' blocks or 'featured' blocks
@@ -20,7 +20,7 @@ const LatestArticles = ({ block, data, blocks }) => {
   const resolvedData = {};
   [resolvedData.first, nextIndex] = getData(data, first, nextIndex);
   [resolvedData.second] = getData(data, second, nextIndex);
-  return <TwoArticlesInRow {...resolvedData} />;
+  return <TwoArticlesInRow {...resolvedData} inViewport={inViewport} />;
 };
 
 LatestArticles.propTypes = {

--- a/features/layout/blocks/articles/TwoArticlesInRow.js
+++ b/features/layout/blocks/articles/TwoArticlesInRow.js
@@ -10,14 +10,22 @@ import styles from './twoInRow.module.scss';
 
 const b = bem(styles);
 
-const TwoArticlesInRow = ({ className, first, second }) => (
+const TwoArticlesInRow = ({ className, first, second, inViewport }) => (
   <BlockWrapper className={cn(b(), className)}>
     <div className={b('first')}>
-      <ArticleCard {...first} blockContext={['two-in-row', 'two-in-row__first']} />
+      <ArticleCard
+        {...first}
+        blockContext={['two-in-row', 'two-in-row__first']}
+        inViewport={inViewport}
+      />
     </div>
     {/* <div className={b('second')}> */}
     <div>
-      <ArticleCard {...second} blockContext={['two-in-row', 'two-in-row__second']} />
+      <ArticleCard
+        {...second}
+        blockContext={['two-in-row', 'two-in-row__second']}
+        inViewport={inViewport}
+      />
     </div>
   </BlockWrapper>
 );

--- a/features/layout/blocks/articles/list-block.js
+++ b/features/layout/blocks/articles/list-block.js
@@ -38,7 +38,7 @@ const arrangeListInBlocks = articles =>
     []
   );
 
-export const ArticlesList = ({ articles }) => {
+export const ArticlesList = ({ articles, inViewport }) => {
   if (articles.length === 1) {
     const { articleId } = articles[0];
     return (
@@ -46,6 +46,7 @@ export const ArticlesList = ({ articles }) => {
         // This is a workaround in order to use FeaturedBlock as it is.
         block={{ frozen: true, articleId }}
         data={{ articles: { [articleId]: articles[0] } }}
+        inViewport={inViewport}
       />
     );
   }
@@ -53,7 +54,9 @@ export const ArticlesList = ({ articles }) => {
   if (articles.length === 3) {
     // If articles' list contains exactly 3 articles, we treat it in a special way:
     // we do not want 3 articles to be rendered in a same way as *3 first articles* are rendered in generic composition.
-    return <TagPageBlockCD articles={articles} layout={LAYOUT_BY_LEVEL.C} />;
+    return (
+      <TagPageBlockCD articles={articles} layout={LAYOUT_BY_LEVEL.C} inViewport={inViewport} />
+    );
   }
 
   const blocks = arrangeListInBlocks(articles);
@@ -61,8 +64,15 @@ export const ArticlesList = ({ articles }) => {
   return blocks.map((block, index) => {
     const levelName = PAGE_LEVEL_ORDER[index % PAGE_LEVEL_ORDER.length];
     const Block = BLOCK_BY_LEVEL[levelName];
-    // eslint-disable-next-line react/no-array-index-key
-    return <Block key={index} articles={block} layout={LAYOUT_BY_LEVEL[levelName]} />;
+    return (
+      <Block
+        // eslint-disable-next-line react/no-array-index-key
+        key={index}
+        articles={block}
+        layout={LAYOUT_BY_LEVEL[levelName]}
+        inViewport={inViewport && index < 1}
+      />
+    );
   });
 };
 
@@ -70,12 +80,17 @@ ArticlesList.propTypes = {
   articles: ArticlePreviewArray.isRequired,
 };
 
-const ArticlesListBlock = ({ block: { articles }, data }) => {
+const ArticlesListBlock = ({ block: { articles }, data, inViewport }) => {
   if (!articles.length) {
     // It's ok to have block template in fibery: it should be ignored unless it is filled with data.
     return null;
   }
-  return <ArticlesList articles={articles.map(articleId => data.articles[articleId])} />;
+  return (
+    <ArticlesList
+      articles={articles.map(articleId => data.articles[articleId])}
+      inViewport={inViewport}
+    />
+  );
 };
 
 ArticlesListBlock.propTypes = {

--- a/features/layout/blocks/banner/BannerBlock.js
+++ b/features/layout/blocks/banner/BannerBlock.js
@@ -38,7 +38,7 @@ const BANNERS = banner =>
     return acc;
   }, {});
 
-const BannerBlock = ({ block: { banner } }) => {
+const BannerBlock = ({ block: { banner }, inViewport }) => {
   const title = useLocalization(`banners.${banner}-title`);
   const subtitle = useLocalization(`banners.${banner}-subtitle`);
 
@@ -57,7 +57,7 @@ const BannerBlock = ({ block: { banner } }) => {
           {banner === NY2021 && (
             <div className={cn(b('subtitle'), b(`${banner}-subtitle`))}>{subtitle}</div>
           )}
-          <Picture sources={BANNERS(banner)} alt={title} />
+          <Picture sources={BANNERS(banner)} alt={title} inViewport={inViewport} />
         </Link>
       </div>
     </BlockWrapper>

--- a/features/layout/blocks/diary/DiaryBlock.js
+++ b/features/layout/blocks/diary/DiaryBlock.js
@@ -21,7 +21,7 @@ import { ROUTES_NAMES } from 'routes';
 
 const b = bem(styles);
 
-const DiaryBlock = ({ lang }) => {
+const DiaryBlock = ({ lang, inViewport }) => {
   const [{ data, next, prev }, setState] = useDiary();
 
   const { month, day } = data;
@@ -52,7 +52,13 @@ const DiaryBlock = ({ lang }) => {
             params={{ slug }}
             noStyles
           >
-            <Image alt={name} sourceSizes={[DIARY_PICTURE_WIDTH]} baseUrl={diaryImage} mode="x" />
+            <Image
+              alt={name}
+              sourceSizes={[DIARY_PICTURE_WIDTH]}
+              baseUrl={diaryImage}
+              mode="x"
+              inViewport={inViewport}
+            />
           </Link>
         )}
         <div className={b('text-content')}>

--- a/features/layout/blocks/index.js
+++ b/features/layout/blocks/index.js
@@ -7,7 +7,7 @@ import ArticlesByTag3 from './articles/ArticlesByTag3';
 import BannerBlock from './banner/BannerBlock';
 import ArticlesListBlock from './articles/list-block';
 
-export default {
+export const BLOCKS_BY_TYPE = {
   featured: FeaturedBlock,
   diary: DiaryBlock,
   latestArticles: LatestArticles,

--- a/features/layout/blocks/tags/TagPageBlockB.js
+++ b/features/layout/blocks/tags/TagPageBlockB.js
@@ -12,7 +12,7 @@ import styles from './tagPageBlockB.module.scss';
 
 const b = bem(styles);
 
-const TagPageBlockB = ({ articles, layout }) => {
+const TagPageBlockB = ({ articles, layout, inViewport }) => {
   const resolvedLayout = articles.length === 1 ? 'large-left' : layout;
 
   const [first, second] =
@@ -24,6 +24,7 @@ const TagPageBlockB = ({ articles, layout }) => {
         <ArticleCard
           {...first}
           blockContext={['tag-page-block-b', 'tag-page-block-b__large-card']}
+          inViewport={inViewport}
         />
       </div>
 
@@ -32,6 +33,7 @@ const TagPageBlockB = ({ articles, layout }) => {
           <ArticleCard
             {...second}
             blockContext={['tag-page-block-b', 'tag-page-block-b__small-card']}
+            inViewport={inViewport}
           />
         ) : (
           <PlaceholderCard blockContext={['tag-page-block-b', 'tag-page-block-b__small-card']} />

--- a/features/layout/blocks/tags/TagPageBlockCD.js
+++ b/features/layout/blocks/tags/TagPageBlockCD.js
@@ -17,7 +17,7 @@ const SIZE_BY_LAYOUT = {
   'row-of-three': 3,
 };
 
-const TagPageBlockCD = ({ articles, layout }) => (
+const TagPageBlockCD = ({ articles, layout, inViewport }) => (
   <BlockWrapper className={b({ layout })}>
     {Array.from({ length: SIZE_BY_LAYOUT[layout] }).map((_, i) => (
       // eslint-disable-next-line react/no-array-index-key
@@ -26,6 +26,7 @@ const TagPageBlockCD = ({ articles, layout }) => (
           <ArticleCard
             {...articles[i]}
             blockContext={['tag-page-block-cd', `tag-page-block-cd__${layout}`]}
+            inViewport={inViewport}
           />
         ) : (
           <PlaceholderCard blockContext={['tag-page-block-cd', `tag-page-block-cd__${layout}`]} />

--- a/features/layout/blocks/tags/TagsByTopic.js
+++ b/features/layout/blocks/tags/TagsByTopic.js
@@ -14,7 +14,7 @@ import styles from './tagsByTopic.module.scss';
 
 const b = bem(styles);
 
-const TagsByTopic = ({ block, data: { tags } }) => {
+const TagsByTopic = ({ block, data: { tags }, inViewport }) => {
   const { topicSlug, tagsIds, style } = block;
   const tagsData = tagsIds.map(id => tags[id]);
   const topicLink = getTopicLink({ topic: topicSlug });
@@ -32,6 +32,7 @@ const TagsByTopic = ({ block, data: { tags } }) => {
                 'tags-by-topic__2',
                 'tags-by-topic__2-top',
               ]}
+              inViewport={inViewport}
             />
           </div>
           <div>
@@ -43,6 +44,7 @@ const TagsByTopic = ({ block, data: { tags } }) => {
                 'tags-by-topic__2',
                 'tags-by-topic__2-bottom',
               ]}
+              inViewport={inViewport}
             />
           </div>
         </div>
@@ -50,6 +52,7 @@ const TagsByTopic = ({ block, data: { tags } }) => {
           <TagCard
             {...tagsData[2]}
             blockContext={['tags-by-topic', `tags-by-topic--style--${style}`, 'tags-by-topic__1']}
+            inViewport={inViewport}
           />
         </div>
       </div>

--- a/features/layout/card-blocks-layout.js
+++ b/features/layout/card-blocks-layout.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import keyBy from 'lodash/keyBy';
 
-import BLOCKS_BY_TYPE from 'features/layout/blocks';
+import { BLOCKS_BY_TYPE } from 'features/layout/blocks';
 
 import {
   ArticlePreviewArray,
@@ -12,16 +12,25 @@ import {
   TagsById,
 } from 'utils/customPropTypes';
 
-const CardBlocksLayout = ({ blocks, data }) => {
+const CardBlocksLayout = ({ blocks, data, inViewport }) => {
   const blocksByType = keyBy(blocks, 'type');
   return blocks.map((block, index) => {
     const Block = BLOCKS_BY_TYPE[block.type];
     if (!Block) {
       return null;
     }
+
+    const maxViewportBlockNumber = block.type === 'banner' ? 2 : 1;
+
     return (
-      // eslint-disable-next-line react/no-array-index-key
-      <Block key={index} block={block} data={data} blocks={blocksByType} />
+      <Block
+        // eslint-disable-next-line react/no-array-index-key
+        key={index}
+        block={block}
+        data={data}
+        blocks={blocksByType}
+        inViewport={inViewport && index < maxViewportBlockNumber}
+      />
     );
   });
 };

--- a/features/layout/cards/article.js
+++ b/features/layout/cards/article.js
@@ -88,6 +88,7 @@ const ArticleCard = props => {
     slug,
     tagsByTopic,
     onBackground,
+    inViewport,
   } = props;
   const { brands = [], authors = [] } = tagsByTopic;
   const { short, full } = ACTION_BY_TYPE[type];
@@ -128,6 +129,7 @@ const ArticleCard = props => {
                 {}
               )}
               alt={title}
+              inViewport={inViewport}
             />
           ) : (
             <Image
@@ -136,6 +138,7 @@ const ArticleCard = props => {
               sourceSizes={[COVER_BY_CARD_SIZE[size].width]}
               baseUrl={images[COVER_BY_CARD_SIZE[size].type]}
               mode="x"
+              inViewport={inViewport}
             />
           ))}
       </div>
@@ -155,6 +158,7 @@ const ArticleCard = props => {
                 sourceSizes={[COLLECTION_LOGO_WIDTH]}
                 baseUrl={collection.cover}
                 mode="x"
+                inViewport={inViewport}
               />
             )}
           </div>
@@ -178,6 +182,7 @@ const ArticleCard = props => {
             getTagImageRenderer({
               className: b('brand'),
               theme,
+              inViewport,
             })
           )}
           <span>{renderNodeList(authors.map(renderTag))}</span>

--- a/features/layout/cards/tag.js
+++ b/features/layout/cards/tag.js
@@ -17,7 +17,7 @@ import styles from './tag.module.scss';
 
 const b = bem(styles);
 
-const TagCard = ({ slug, topicSlug, content, size, blockContext }) => {
+const TagCard = ({ slug, topicSlug, content, size, blockContext, inViewport }) => {
   const { theme, color = '#ffffff' } = content;
 
   const wrapperProps = {
@@ -66,6 +66,7 @@ const TagCard = ({ slug, topicSlug, content, size, blockContext }) => {
               sourceSizes={[390]}
               baseUrl={image}
               mode="x"
+              inViewport={inViewport}
             />
           )}
         </div>

--- a/pages/about.js
+++ b/pages/about.js
@@ -71,7 +71,7 @@ const AboutPage = ({ lang }) => (
           {PARTNERS.map(({ id, img, url, size = undefined }) => (
             <div key={id} className={b('partner-logo', { size })}>
               <ExternalLink href={url}>
-                <img src={img} alt={localize(`about.${id}`, lang)} />
+                <img src={img} alt={localize(`about.${id}`, lang)} loading="lazy" />
               </ExternalLink>
             </div>
           ))}

--- a/pages/collection.js
+++ b/pages/collection.js
@@ -39,6 +39,7 @@ const CollectionPage = ({ slug, collection, metaKeywords, articles, authors }) =
             sourceSizes={[90]}
             baseUrl={collection.cover}
             mode="x"
+            inViewport
           />
           <div className={b('text')}>
             <div className={b('subheading')}>

--- a/pages/diary.js
+++ b/pages/diary.js
@@ -81,6 +81,7 @@ const DiaryPage = ({
               sourceSizes={[DIARY_PICTURE_WIDTH]}
               baseUrl={image}
               mode="x"
+              inViewport
             />
           )}
         </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -12,7 +12,7 @@ const MainPage = ({ blocks, data, diary, lang }) => {
   const localized = useMemo(() => localizeData(data, lang), [data, lang]);
   return (
     <DiaryProvider value={diary}>
-      <CardBlocksLayout blocks={blocks} data={localized} />
+      <CardBlocksLayout blocks={blocks} data={localized} inViewport />
     </DiaryProvider>
   );
 };

--- a/utils/features/tags.js
+++ b/utils/features/tags.js
@@ -61,7 +61,7 @@ export const getTagImageUrl = ({
   return images[BRAND_LOGO_BY_THEME[theme]];
 };
 
-export const getTagImageRenderer = ({ className, theme = DEFAULT_THEME }) => ({
+export const getTagImageRenderer = ({ className, theme = DEFAULT_THEME, inViewport }) => ({
   slug,
   topicSlug,
   content,
@@ -74,5 +74,6 @@ export const getTagImageRenderer = ({ className, theme = DEFAULT_THEME }) => ({
     baseUrl={getTagImageUrl({ topicSlug, content, theme })}
     mode="x"
     dimension="h"
+    inViewport={inViewport}
   />
 );

--- a/utils/fibery/renderer.js
+++ b/utils/fibery/renderer.js
@@ -155,7 +155,7 @@ const RENDERERS = {
     }
     return (
       <span key={key} className={styles['article-image']}>
-        <img className={styles['article-image__image']} src={url} alt={alt} />
+        <img className={styles['article-image__image']} src={url} alt={alt} loading="lazy" />
         <span className={styles['article-image__caption']}>{title}</span>
       </span>
     );


### PR DESCRIPTION
- https://web.dev/browser-level-image-lazy-loading/

# loaded images
## home
 _ | count | size
-- | -- | --
was | 19 | 3 000,4 KiB
now | 10 | 1 741,4 KiB

## tag/belarus
 _ | count | size
-- | -- | --
was | 42 | 9 113,3 KiB
now | 11 | 2 416,7 KiB

## article/kitaby
 _ | count | size
-- | -- | --
was | 9 | 2 882,2 KiB
now | 3 | 1 051 KiB




